### PR TITLE
Install pciutils for lspci

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Now we can install the packages we need:
 ```
 yum -y clean all
 yum -y update
-yum -y install lshw emacs gcc git python-devel python-setuptools python-pip \
+yum -y install lshw emacs gcc git pciutils python-devel python-setuptools python-pip \
                tmux tuned-profiles-cpu-partitioning wget
 ```
 


### PR DESCRIPTION
lspci is used by dpdk_setup_ports.py
```                                        
# ./dpdk_setup_ports.py -i                                                      
By default, IP based configuration file will be created. Do you want to use MAC based config? (y/N)y
Traceback (most recent call last):                                              
  File "./dpdk_setup_ports.py", line 1181, in main                              
    obj.do_interactive_create();                                                
  File "./dpdk_setup_ports.py", line 923, in do_interactive_create              
    self.run_dpdk_lspci()                                                       
  File "./dpdk_setup_ports.py", line 563, in run_dpdk_lspci                     
    dpdk_nic_bind.get_nic_details()                                             
  File "/root/trex/v2.29/dpdk_nic_bind.py", line 273, in get_nic_details        
    dev_lines = check_output(["lspci", "-Dvmmn"], universal_newlines = True).splitlines()
  File "/root/trex/v2.29/dpdk_nic_bind.py", line 154, in check_output           
    stderr=stderr, **kwargs).communicate()[0]                                   
  File "/usr/lib64/python2.7/subprocess.py", line 711, in __init__              
    errread, errwrite)                                                          
  File "/usr/lib64/python2.7/subprocess.py", line 1327, in _execute_child       
    raise child_exception                                                       
OSError: [Errno 2] No such file or directory
#
```