### PR TITLE
Added couple of new options and changed the command to fetch number of flows

### DIFF
--- a/ovs_performance.py
+++ b/ovs_performance.py
@@ -240,9 +240,7 @@ def test_p2v2p(nr_of_flows, packet_sizes):
 
     p2v2p_results = list()
     cpu_results = list()
-    wait_time = 0
-    active_flows = 0
-    warm_up_error = 0
+    warm_up_done = False
 
     for packet_size in packet_sizes:
 
@@ -275,26 +273,15 @@ def test_p2v2p(nr_of_flows, packet_sizes):
 
             tester.start_traffic(config.tester_interface)
 
-            warm_up_error = warm_up_verify(nr_of_flows * 2,
+            warm_up_done = warm_up_verify(nr_of_flows * 2,
                                         config.warm_up_timeout)
             tester.stop_traffic(config.tester_interface)
 
-            if warm_up_error:
+            if not warm_up_done:
                 if config.warm_up_no_fail:
 
                     stop_traffic_loop_on_vm(config.dut_vm_address)
-
-		    lprint("INFO: Waiting for Datapath flows to flush")
-
-                    active_flows = get_active_datapath_flows()
-                    wait_time = 0
-                    while active_flows > 32:
-                        wait_time += 1
-                        if wait_time >= 20:
-                            lprint("ERROR: Failed to complete cool-down in time (20 seconds)!")
-                            sys.exit(-1)
-                        active_flows = get_active_datapath_flows()
-                        time.sleep(1)
+                    flow_table_cool_down()
                 else:
                     sys.exit(-1)
 
@@ -309,7 +296,7 @@ def test_p2v2p(nr_of_flows, packet_sizes):
             = get_of_port_packet_stats(of_interfaces[config.virtual_interface])
 
         ##################################################
-        if not config.warm_up or warm_up_error:
+        if not config.warm_up or not warm_up_done:
             lprint("  * Start packet receiver on VM...")
             start_traffic_loop_on_vm(config.dut_vm_address,
                                      config.dut_vm_nic_pci)
@@ -435,9 +422,7 @@ def test_p2v(nr_of_flows, packet_sizes):
 
     p2v_results = list()
     cpu_results = list()
-    wait_time = 0
-    active_flows = 0
-    warm_up_error = 0
+    warm_up_done = False
 
     for packet_size in packet_sizes:
 
@@ -464,21 +449,11 @@ def test_p2v(nr_of_flows, packet_sizes):
         if config.warm_up:
             lprint("  * Doing flow table warm-up...")
             tester.start_traffic(config.tester_interface)
-            warm_up_error = warm_up_verify(nr_of_flows, config.warm_up_timeout)
+            warm_up_done = warm_up_verify(nr_of_flows, config.warm_up_timeout)
             tester.stop_traffic(config.tester_interface)
-            if warm_up_error:
+            if not warm_up_done:
                 if config.warm_up_no_fail:
-		    lprint("INFO: Waiting for Datapath flows to flush")
-
-                    active_flows = get_active_datapath_flows()
-                    wait_time = 0
-                    while active_flows > 32:
-                        wait_time += 1
-                        if wait_time >= 20:
-                            lprint("ERROR: Failed to complete cool-down in time (20 seconds)!")
-                            sys.exit(-1)
-                        active_flows = get_active_datapath_flows()
-                        time.sleep(1)
+                    flow_table_cool_down()
                 else:
                     sys.exit(-1)
 
@@ -585,9 +560,7 @@ def test_p2p(nr_of_flows, packet_sizes):
 
     p2p_results = list()
     cpu_results = list()
-    wait_time = 0
-    active_flows = 0
-    warm_up_error = 0
+    warm_up_done = False
 
     for packet_size in packet_sizes:
 
@@ -615,21 +588,11 @@ def test_p2p(nr_of_flows, packet_sizes):
         if config.warm_up:
             lprint("  * Doing flow table warm-up...")
             tester.start_traffic(config.tester_interface)
-            warm_up_error = warm_up_verify(nr_of_flows, config.warm_up_timeout)
+            warm_up_done = warm_up_verify(nr_of_flows, config.warm_up_timeout)
             tester.stop_traffic(config.tester_interface)
-            if warm_up_error:
+            if not warm_up_done:
                 if config.warm_up_no_fail:
-		    lprint("INFO: Waiting for Datapath flows to flush")
-
-                    active_flows = get_active_datapath_flows()
-                    wait_time = 0
-                    while active_flows > 32:
-                        wait_time += 1
-                        if wait_time >= 20:
-                            lprint("ERROR: Failed to complete cool-down in time (20 seconds)!")
-                            sys.exit(-1)
-                        active_flows = get_active_datapath_flows()
-                        time.sleep(1)
+                    flow_table_cool_down()
                 else:
                     sys.exit(-1)
 
@@ -909,17 +872,41 @@ def warm_up_verify(requested_flows, timeout):
     while active_flows < requested_flows:
         run_time += 1
         if timeout != 0 and run_time >= timeout:
-	        lprint("ERROR: Failed to complete warm-up in time ({} seconds)!".
-                       format(timeout))
-                return 1
+            lprint("ERROR: Failed to complete warm-up in time ({} seconds)!".
+                     format(timeout))
+            return False
 
         time.sleep(1)
         active_flows = get_active_datapath_flows()
     #
     # Flows exist, we can continue now
     #
-    return 0
+    return True
 
+
+#
+# Wait for datapth flows to flush
+#
+def flow_table_cool_down(failure_fatal=True):
+    run_time = 0
+    active_flows = 0
+
+    if config.warm_up or not config.no_cool_down:
+        lprint("  * Doing flow table cool-down...")
+        active_flows = get_active_datapath_flows()
+
+        while active_flows > 32:
+            run_time += 1
+            if run_time >= 20:
+                if failure_fatal:
+                    lprint("ERROR: Failed to complete cool-down in time (20 seconds)!")
+                    sys.exit(-1)
+                else:
+                    lprint("WARNING: Failed to complete cool-down in time (20 seconds)!")
+                    break
+
+            active_flows = get_active_datapath_flows()
+            time.sleep(1)
 
 #
 # Flush all OVS flows
@@ -944,21 +931,9 @@ def flush_ovs_flows():
 
     dut_shell.dut_exec(cmd, die_on_error=True)
 
-    if config.warm_up or not config.no_cool_down:
-        lprint("  * Doing flow table cool-down...")
-        active_flows = get_active_datapath_flows()
-        run_time = 0
+    flow_table_cool_down(failure_fatal=False)
+    time.sleep(2)
 
-        while active_flows > 32:
-            run_time += 1
-            if run_time >= 20:
-                lprint("WARNING: Failed to complete cool-down in time (20 seconds)!")
-                break
-
-            active_flows = get_active_datapath_flows()
-            time.sleep(1)
-
-        time.sleep(2)
 
 
 #

--- a/ovs_performance.py
+++ b/ovs_performance.py
@@ -287,6 +287,7 @@ def test_p2v2p(nr_of_flows, packet_sizes):
 		    lprint("INFO: Waiting for Datapath flows to flush")
 
                     active_flows = get_active_datapath_flows()
+                    wait_time = 0
                     while active_flows > 32:
                         wait_time += 1
                         if wait_time >= 20:
@@ -470,6 +471,7 @@ def test_p2v(nr_of_flows, packet_sizes):
 		    lprint("INFO: Waiting for Datapath flows to flush")
 
                     active_flows = get_active_datapath_flows()
+                    wait_time = 0
                     while active_flows > 32:
                         wait_time += 1
                         if wait_time >= 20:
@@ -620,6 +622,7 @@ def test_p2p(nr_of_flows, packet_sizes):
 		    lprint("INFO: Waiting for Datapath flows to flush")
 
                     active_flows = get_active_datapath_flows()
+                    wait_time = 0
                     while active_flows > 32:
                         wait_time += 1
                         if wait_time >= 20:


### PR DESCRIPTION
Hi,

I have added two new options to the script.
1. --warm-up-no-fail: It is possible that a millions of flows cannot stay together in the system so there are chances of warm up failure. To deal with such situations I added this new option. If the warm up fails and this option is set then the script will wait for all the flows to flush but will continue with the test.
2. --warm-up-timeout: Option to bail out of warm up early. Default 360 seconds looks too large.

Also, ovs-appctl dpctl/dump-flows can take a lot of time when large number of flows. Instead using ovs-appctl dpctl/show to fetch current number of flows.